### PR TITLE
refac: add more posts utils

### DIFF
--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -10,6 +10,7 @@ const blogCollection = defineCollection({
     description: z.string(),
     updatedAt: z.date().optional(),
     relatedPosts: z.array(z.string()).optional(),
+    isFeatured: z.boolean().optional(),
   }),
 });
 

--- a/src/pages/blog/[slug].astro
+++ b/src/pages/blog/[slug].astro
@@ -4,7 +4,7 @@ import PostDetails from '~/layouts/PostDetails.astro';
 import Posts from '~/layouts/Posts.astro';
 import { site } from '~/utils/config';
 import getPageNumbers from '~/utils/pageNumbers';
-import sortPosts from '~/utils/sortPosts';
+import { getSortedPosts } from '~/utils/sortPosts';
 
 export interface Props {
   post: CollectionEntry<'blogs'>;
@@ -26,10 +26,8 @@ export async function getStaticPaths() {
 
 const { slug } = Astro.params;
 
-const posts = await getCollection('blogs');
 const post = await getEntry({ collection: 'blogs', slug: slug! });
-
-const sortedPosts = sortPosts(posts);
+const sortedPosts = await getSortedPosts();
 
 const totalPages = getPageNumbers(sortedPosts.length);
 

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -1,14 +1,10 @@
 ---
-import { getCollection } from 'astro:content';
 import Posts from '~/layouts/Posts.astro';
 import { site } from '~/utils/config';
-import sortPosts from '~/utils/sortPosts';
+import { getSortedPosts } from '~/utils/sortPosts';
 import getPageNumbers from '~/utils/pageNumbers';
 
-const posts = await getCollection('blogs', ({ data }) => !data.isDraft);
-
-const sortedPosts = sortPosts(posts);
-
+const sortedPosts = await getSortedPosts();
 const totalPages = getPageNumbers(sortedPosts.length);
 
 const paginatedPosts = sortedPosts.slice(0, site.postPerPage);

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,17 +1,13 @@
 ---
-import { getCollection } from 'astro:content';
 import Card from '~/components/Card.astro';
 import Footer from '~/components/Footer.astro';
 import Header from '~/components/Header.astro';
 import Hr from '~/components/Hr.astro';
 import Link from '~/components/Link.astro';
 import Layout from '~/layouts/Layout.astro';
-import sortPosts from '~/utils/sortPosts';
+import { getLatestPosts } from '~/utils/sortPosts';
 
-const posts = await getCollection('blogs', ({ data }) => !data.isDraft);
-
-const sortedPosts = sortPosts(posts);
-const latestPosts = sortedPosts.slice(0, 3);
+const latestPosts = await getLatestPosts() 
 ---
 
 <Layout>

--- a/src/pages/tags/[tag].astro
+++ b/src/pages/tags/[tag].astro
@@ -7,7 +7,7 @@ import Layout from '~/layouts/Layout.astro';
 import Main from '~/layouts/Main.astro';
 import { site } from '~/utils/config';
 import getTags from '~/utils/getTags';
-import sortPosts from '~/utils/sortPosts';
+import { sortPosts } from '~/utils/sortPosts';
 
 export interface Props {
   post: CollectionEntry<'blogs'>;

--- a/src/utils/sortPosts.ts
+++ b/src/utils/sortPosts.ts
@@ -1,8 +1,20 @@
-import type { CollectionEntry } from 'astro:content';
+import { type CollectionEntry, getCollection } from 'astro:content';
 import dayjs from 'dayjs';
 
-export default function sortPosts(posts: CollectionEntry<'blogs'>[]) {
+export function sortPosts(posts: CollectionEntry<'blogs'>[]) {
   return posts.sort((a, b) =>
     dayjs(a.data.pubDate).isBefore(b.data.pubDate) ? 1 : -1,
   );
+}
+
+export async function getSortedPosts(): Promise<CollectionEntry<'blogs'>[]> {
+  const posts = await getCollection('blogs', ({ data }) => !data.isDraft);
+  return sortPosts(posts);
+}
+
+export async function getLatestPosts(
+  num = 3,
+): Promise<CollectionEntry<'blogs'>[]> {
+  const posts = await getSortedPosts();
+  return posts.slice(0, num);
 }

--- a/src/utils/sortPosts.ts
+++ b/src/utils/sortPosts.ts
@@ -18,3 +18,10 @@ export async function getLatestPosts(
   const posts = await getSortedPosts();
   return posts.slice(0, num);
 }
+
+export async function getFeaturedPosts(): Promise<CollectionEntry<'blogs'>[]> {
+  return await getCollection(
+    'blogs',
+    ({ data }) => data.isFeatured && !data.isDraft,
+  );
+}


### PR DESCRIPTION
## Description

This PR will add a few util functions to get specified posts:
- `getLatestPosts`
- `getSortedPosts`
- `getFeaturedPosts`

The `isFeatured` flag has not been set in any post yet, but it may be used in the future.