### PR TITLE
feat: animate code blocks

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,8 @@
     "hastscript": "^9.0.0",
     "mdast-util-to-string": "^4.0.0",
     "reading-time": "^1.5.0",
+    "shiki": "^1.3.0",
+    "shiki-magic-move": "^0.3.7",
     "svelte": "5.0.0-next.110",
     "tailwindcss": "^3.4.3"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,6 +47,12 @@ dependencies:
   reading-time:
     specifier: ^1.5.0
     version: 1.5.0
+  shiki:
+    specifier: ^1.3.0
+    version: 1.3.0
+  shiki-magic-move:
+    specifier: ^0.3.7
+    version: 0.3.7(shiki@1.3.0)
   svelte:
     specifier: 5.0.0-next.110
     version: 5.0.0-next.110
@@ -2465,6 +2471,10 @@ packages:
 
   /didyoumean@1.2.2:
     resolution: {integrity: sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==}
+    dev: false
+
+  /diff-match-patch-es@0.1.0:
+    resolution: {integrity: sha512-y+HzthUzXXodKmawgRo9gQivKhY/NGzkZURFMQWSWsdRpOpkjjmX9DfDWB/T4a3blVqKoXL6f8Spq1+dLd+csQ==}
     dev: false
 
   /diff@5.2.0:
@@ -5095,6 +5105,10 @@ packages:
       es-object-atoms: 1.0.0
     dev: true
 
+  /ohash@1.1.3:
+    resolution: {integrity: sha512-zuHHiGTYTA1sYJ/wZN+t5HKZaH23i4yI1HMwbuXm24Nid7Dv0KcuRlKoNKS9UNfAVSBlnGLcuQrnOKWOZoEGaw==}
+    dev: false
+
   /once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
     requiresBuild: true
@@ -5949,6 +5963,25 @@ packages:
   /shebang-regex@3.0.0:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
+
+  /shiki-magic-move@0.3.7(shiki@1.3.0):
+    resolution: {integrity: sha512-htk8yuymLkh2yi5mwS5hRU3MwcasSW7qsPWsjTK5uEs+FELCrNAO9OJwtEvpZTZ58aRL0pj6aKeF74AESVkI3g==}
+    peerDependencies:
+      react: ^18.2.0
+      shiki: ^1.1.6
+      vue: ^3.4.0
+    peerDependenciesMeta:
+      react:
+        optional: true
+      shiki:
+        optional: true
+      vue:
+        optional: true
+    dependencies:
+      diff-match-patch-es: 0.1.0
+      ohash: 1.1.3
+      shiki: 1.3.0
+    dev: false
 
   /shiki@1.3.0:
     resolution: {integrity: sha512-9aNdQy/etMXctnPzsje1h1XIGm9YfRcSksKOGqZWXA/qP9G18/8fpz5Bjpma8bOgz3tqIpjERAd6/lLjFyzoww==}

--- a/src/components/AnimateCodeBlock.svelte
+++ b/src/components/AnimateCodeBlock.svelte
@@ -1,0 +1,52 @@
+<script lang="ts">
+  import { getHighlighter } from 'shiki';
+  import ShikiMagicMove from './ShikiMagicMove.svelte';
+
+  let {
+    previous,
+    next,
+    lang,
+  }: { previous: string; next: string; lang: string } = $props();
+
+  let code = $state(previous);
+
+  const highlighter = getHighlighter({
+    themes: ['catppuccin-mocha', 'synthwave-84'],
+    langs: [lang],
+  });
+
+  const theme =
+    document.documentElement.getAttribute('data-theme') === 'dark'
+      ? 'catppuccin-mocha'
+      : 'synthwave-84';
+</script>
+
+{#await highlighter then highlighter}
+  <ShikiMagicMove
+    options={{ duration: 600, stagger: 3, animateContainer: true }}
+    {theme}
+    {highlighter}
+    {code}
+    {lang}
+  />
+  <button
+    class="text-custom-base hover:text-custom-accent"
+    onclick={() => (code === previous ? (code = next) : (code = previous))}
+  >
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      fill="none"
+      viewBox="0 0 24 24"
+      stroke-width="1.5"
+      stroke="currentColor"
+      class="w-6 h-6"
+    >
+      <path
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        d="M5.25 5.653c0-.856.917-1.398 1.667-.986l11.54 6.347a1.125 1.125 0 0 1 0 1.972l-11.54 6.347a1.125 1.125 0 0 1-1.667-.986V5.653Z"
+      />
+    </svg>
+    Animate code
+  </button>
+{/await}

--- a/src/components/SearchBar.svelte
+++ b/src/components/SearchBar.svelte
@@ -5,7 +5,7 @@
   import SearchResults from './SearchResults.svelte';
   import type { SearchList, SearchResult } from '~/utils/types';
 
-  const { posts } = $props<{ posts: CollectionEntry<'blogs'>[] }>();
+  const { posts }: { posts: CollectionEntry<'blogs'>[] } = $props();
   const searchList = posts.map((p) => {
     return {
       title: p.data.title,

--- a/src/components/ShikiMagicMove.svelte
+++ b/src/components/ShikiMagicMove.svelte
@@ -1,0 +1,40 @@
+<script lang="ts">
+  import {
+    codeToKeyedTokens,
+    createMagicMoveMachine,
+    type MagicMoveDifferOptions,
+    type MagicMoveRenderOptions,
+  } from 'shiki-magic-move/core';
+  import ShikiMagicMoveRenderer from './ShikiMagicMoveRenderer.svelte';
+  import type { HighlighterCore } from 'shiki';
+
+  interface ShikiMagicMoveProps {
+    highlighter: HighlighterCore;
+    lang: string;
+    theme: string;
+    code: string;
+    options?: MagicMoveRenderOptions & MagicMoveDifferOptions;
+    onStart?: () => void;
+    onEnd?: () => void;
+  }
+  const { ...props }: ShikiMagicMoveProps = $props();
+
+  const machine = createMagicMoveMachine(
+    (code) =>
+      codeToKeyedTokens(props.highlighter, code, {
+        lang: props.lang,
+        theme: props.theme,
+      }),
+    props.options,
+  );
+  const result = $derived(machine.commit(props.code));
+</script>
+
+<ShikiMagicMoveRenderer
+  animate={true}
+  tokens={result.current}
+  previous={result.previous}
+  options={props.options}
+  onStart={props.onStart}
+  onEnd={props.onEnd}
+/>

--- a/src/components/ShikiMagicMoveRenderer.svelte
+++ b/src/components/ShikiMagicMoveRenderer.svelte
@@ -1,0 +1,58 @@
+<script lang="ts">
+  import { MagicMoveRenderer } from 'shiki-magic-move/renderer';
+  import type {
+    KeyedTokensInfo,
+    MagicMoveRenderOptions,
+  } from 'shiki-magic-move/types';
+
+  interface ShikiMagicMoveRendererProps {
+    class?: string;
+    animate?: boolean;
+    tokens: KeyedTokensInfo;
+    previous?: KeyedTokensInfo;
+    options?: MagicMoveRenderOptions;
+    onStart?: () => void;
+    onEnd?: () => void;
+  }
+  const { ...props }: ShikiMagicMoveRendererProps = $props();
+
+  let container: HTMLPreElement;
+  let renderer: MagicMoveRenderer;
+  let isMounted = $state(false);
+
+  $effect(() => {
+    if (!container) return;
+    container.innerHTML = '';
+    isMounted = true;
+    renderer = new MagicMoveRenderer(container);
+  });
+
+  $effect(() => {
+    async function render() {
+      if (!renderer) return;
+      Object.assign(renderer.options, props.options);
+      if (props.animate) {
+        if (props.previous) renderer.replace(props.previous);
+        props.onStart?.();
+        await renderer.render(props.tokens);
+        props.onEnd?.();
+      } else {
+        renderer.replace(props.tokens);
+      }
+    }
+    render();
+  });
+</script>
+
+<pre bind:this={container} class="shiki-magic-move-container">
+  {#if !isMounted}
+    {#each props.tokens.tokens as token}
+      {#if token.content === '\n'}
+        <br />
+      {/if}
+      <span class="shiki-magic-move-item">
+        {token.content}
+      </span>
+    {/each}
+  {/if}
+</pre>

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -118,6 +118,70 @@
   pre > code {
     white-space: pre;
   }
+
+  .shiki-magic-move-container {
+    position: relative;
+    white-space: pre;
+  }
+
+  .shiki-magic-move-line-number {
+    opacity: 0.3;
+    user-select: none;
+  }
+
+  .shiki-magic-move-item {
+    display: inline-block;
+    transition: color var(--smm-duration, 0.5s) var(--smm-easing, 'ease');
+  }
+
+  .shiki-magic-move-move {
+    transition: all var(--smm-duration, 0.5s) var(--smm-easing, 'ease');
+  }
+
+  .shiki-magic-move-enter-active,
+  .shiki-magic-move-leave-active {
+    transition: all var(--smm-duration, 0.5s) var(--smm-easing, 'ease');
+  }
+
+  .shiki-magic-move-container-resize,
+  .shiki-magic-move-container-restyle {
+    transition: all var(--smm-duration, 0.5s) var(--smm-easing, 'ease');
+    transition-delay: calc(
+      var(--smm-duration, 0.5s) * var(--smm-delay-container, 1)
+    );
+  }
+
+  .shiki-magic-move-move {
+    transition-delay: calc(
+      calc(var(--smm-duration, 0.5s) * var(--smm-delay-move, 1)) +
+        var(--smm-stagger, 0)
+    );
+    z-index: 1;
+  }
+
+  .shiki-magic-move-enter-active {
+    transition-delay: calc(
+      calc(var(--smm-duration, 0.5s) * var(--smm-delay-enter, 1)) +
+        var(--smm-stagger, 0)
+    );
+    z-index: 1;
+  }
+
+  .shiki-magic-move-leave-active {
+    transition-delay: calc(
+      calc(var(--smm-duration, 0.5s) * var(--smm-delay-leave, 1)) +
+        var(--smm-stagger, 0)
+    );
+  }
+
+  .shiki-magic-move-enter-from,
+  .shiki-magic-move-leave-to {
+    opacity: 0;
+  }
+
+  br.shiki-magic-move-leave-active {
+    display: none;
+  }
 }
 
 @layer components {


### PR DESCRIPTION
## Description

This PR adds an `<AnimateCodeBlock>` component to use in the blog posts. It takes as props:
- `previous`: the code the animation starts with
- `next`: the code the animation ends with
- `lang`: the language used in the code block, for syntax highlighting

It uses the [`shiki-magic-move`](https://github.com/shikijs/shiki-magic-move) package and wrapped the renderer into a Svelte component