### PR TITLE
fix(a11y): dont autoanimate when reduced motion is set

### DIFF
--- a/public/toggle-theme.js
+++ b/public/toggle-theme.js
@@ -1,14 +1,9 @@
-const primaryColorScheme = ''; // "light" | "dark"
-
 // Get theme data from local storage
 const currentTheme = localStorage.getItem('theme');
 
 function getPreferTheme() {
   // return theme value in local storage if it is set
   if (currentTheme) return currentTheme;
-
-  // return primary color scheme if it is set
-  if (primaryColorScheme) return primaryColorScheme;
 
   // return user device's prefer color scheme
   return window.matchMedia('(prefers-color-scheme: dark)').matches
@@ -34,23 +29,6 @@ function reflectPreference() {
 
   document.querySelector('#theme-btn')?.setAttribute('aria-label', themeValue);
   document.querySelector('#theme-btn2')?.setAttribute('aria-label', themeValue);
-
-  // Get a reference to the body element
-  const body = document.body;
-
-  // Check if the body element exists before using getComputedStyle
-  if (body) {
-    // Get the computed styles for the body element
-    const computedStyles = window.getComputedStyle(body);
-
-    // Get the background color property
-    const bgColor = computedStyles.backgroundColor;
-
-    // Set the background color in <meta theme-color ... />
-    document
-      .querySelector("meta[name='theme-color']")
-      ?.setAttribute('content', bgColor);
-  }
 }
 
 // set early so no page flashes / CSS is made aware

--- a/src/components/AnimateCodeBlock.svelte
+++ b/src/components/AnimateCodeBlock.svelte
@@ -22,9 +22,15 @@
       ? 'catppuccin-mocha'
       : 'synthwave-84';
 
+  const reducedMotion = window.matchMedia(
+    '(prefers-reduced-motion: reduce)',
+  ).matches;
+
   const observer = new IntersectionObserver(
     (entries) => {
       entries.forEach((entry) => {
+        if (reducedMotion) return;
+
         if (entry.isIntersecting) {
           observer.disconnect();
           setTimeout(() => {


### PR DESCRIPTION
## Description

This PR disables the autoanimation feature of the animated code blocks if the user set their system settings to reduce motion.
It does not change automatically if the user updates their settings, a page reload would be necessary, but I'd guess this is okay